### PR TITLE
Added Platforms: Paqmind.com

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -85,6 +85,10 @@ just too humble about his creation.
 - [The Algebra of Algebraic Data Types](https://www.youtube.com/watch?v=YScIPA8RbVE) - Very good explanation
 on the relationship between math and Algebraic Data Types, which is the Type System of some very common FP Languages such as Haskell and ML.
 
+### Platforms
+
+- [Paqmind.com] – Guides and challenges to learn and improve in programming. All content is CS and FP oriented.
+
 ### Tools
 - [Isabelle/HOL](https://www.cl.cam.ac.uk/research/hvg/Isabelle/) - Generic proof assistant based on Higher Order Logic	
 


### PR DESCRIPTION
Hi, Lucas. Can I suggest you to check (and possibly add) a new platform we currently developing:
[paqmind.com](http://paqmind.com)

We see it as "freeCodeCamp" / "KhanAcademy" inspired alternative. There's a lot of valuable unique free content already (and we update almost daily). But we don't have budget for marketing so I'd like more people to find it via GitHub and awesome list like yours ;)

There's a serie of courses dedicated to FP but the whole content of Paqmind is heavily FP oriented. So I decided to add a link to the site itself, rather than some single course.